### PR TITLE
Idiomatic changes to Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,10 @@ import (
 	airship "github.com/username/library"
 )
 
-airship.Configure(&airship.Client{
-	EnvKey:  "envKey",
-	EdgeURL: "http://localhost:5000",
-})
-
+airship.Configure(airship.New(envKey, edgeURL))
 ```
 
-Here, `envKey` is the environment key you can get from the [**Airship UI**](https://app.airshiphq.com), and the `EdgeURL` points to your [**Airship Microservice**](https://github.com/airshiphq/airship-microservice) URL.
+Here, `envKey` is the environment key you can get from the [**Airship UI**](https://app.airshiphq.com), and the `edgeURL` points to your [**Airship Microservice**](https://github.com/airshiphq/airship-microservice) URL.
 
 ## 04 Usage
 ```

--- a/airship.go
+++ b/airship.go
@@ -49,6 +49,13 @@ type clientParams struct {
 	client *http.Client
 }
 
+// WithHTTPClient sets the *http.Client used by the returned Client.
+func WithHTTPClient(c *http.Client) ClientOption {
+	return func(p *clientParams) {
+		p.client = c
+	}
+}
+
 var defaultClient = &Client{}
 
 // Configure sets up a Airship Go SDK singleton for the airship package.

--- a/airship.go
+++ b/airship.go
@@ -174,13 +174,17 @@ func getObjectValues(flag *FeatureFlag, client *Client, entity interface{}) (*ob
 		return nil, err
 	}
 
-	res, err := client.client.Post(client.url, "application/json", bytes.NewBuffer(requestObj))
+	resp, err := client.client.Post(client.url, "application/json", bytes.NewBuffer(requestObj))
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/airship.go
+++ b/airship.go
@@ -186,6 +186,9 @@ func getObjectValues(flag *FeatureFlag, client *Client, entity interface{}) (*ob
 	}
 
 	var objectValues objectValuesContainer
-	json.Unmarshal(body, &objectValues)
+	if err := json.Unmarshal(body, &objectValues); err != nil {
+		return nil, err
+	}
+
 	return &objectValues, nil
 }

--- a/airship.go
+++ b/airship.go
@@ -10,6 +10,11 @@ import (
 )
 
 const (
+	// TreatmentOff indicates that an entity is not part of a treatment.
+	TreatmentOff = "off"
+	// TreatmentOn indicates that an entity is part of a treatment.
+	TreatmentOn = "on"
+
 	defaultTimeout = 10 * time.Second
 )
 
@@ -88,7 +93,7 @@ func (c *Client) Flag(flagName string) *FeatureFlag {
 func (f *FeatureFlag) GetTreatment(entity interface{}) (string, error) {
 	treatment, err := getTreatment(f, f.Client, entity)
 	if err != nil {
-		return "", fmt.Errorf("airship: %v", err)
+		return TreatmentOff, fmt.Errorf("airship: %v", err)
 	}
 	return treatment, nil
 }
@@ -96,7 +101,7 @@ func (f *FeatureFlag) GetTreatment(entity interface{}) (string, error) {
 func getTreatment(flag *FeatureFlag, client *Client, entity interface{}) (string, error) {
 	objectValues, err := getObjectValues(flag, client, entity)
 	if err != nil {
-		return "", err
+		return TreatmentOff, err
 	}
 	return objectValues.Treatment, nil
 }

--- a/airship.go
+++ b/airship.go
@@ -12,8 +12,6 @@ import (
 const (
 	// TreatmentOff indicates that an entity is not part of a treatment.
 	TreatmentOff = "off"
-	// TreatmentOn indicates that an entity is part of a treatment.
-	TreatmentOn = "on"
 
 	defaultTimeout = 10 * time.Second
 )

--- a/example/main.go
+++ b/example/main.go
@@ -22,10 +22,10 @@ func main() {
 }
 
 func newInstanceTest() {
-	airshipInstance := &airship.Client{
-		EnvKey:  os.Getenv("ENV_KEY"),
-		EdgeURL: "http://localhost:5000",
-	}
+	envKey := os.Getenv("ENV_KEY")
+	edgeURL := "http://localhost:5000"
+	airshipInstance := airship.New(envKey, edgeURL)
+
 	airshipInstanceBitcoinPay := airshipInstance.Flag("bitcoin-pay")
 	myEntity := &Entity{
 		ID: "1",
@@ -44,10 +44,10 @@ func newInstanceTest() {
 }
 
 func singletonTest() {
-	airship.Configure(&airship.Client{
-		EnvKey:  os.Getenv("ENV_KEY"),
-		EdgeURL: "http://localhost:5000",
-	})
+	envKey := os.Getenv("ENV_KEY")
+	edgeURL := "http://localhost:5000"
+	airship.Configure(airship.New(envKey, edgeURL))
+
 	airshipBitcoinPay := airship.Flag("bitcoin-pay")
 	myEntity := &Entity{
 		ID: "2",


### PR DESCRIPTION
Hey Airship team, thanks for publishing a Go client!

This PR makes a few idiomatic changes to the Client, feel free to push back on any changes you don't agree with. The main changes are:

* Create Clients with a `New` constructor rather than struct literals.
* The `New` constructor accepts functional options, including allowing users to provide their own `http.Client` struct with their own set of middlewares and configs.
* `Flag` methods return any errors instead of default values. As a user I would rather know if a call failed than think it succeed and use a wrong value.